### PR TITLE
fix(fly): correct misplaced text within code block

### DIFF
--- a/src/6-fly.md
+++ b/src/6-fly.md
@@ -981,6 +981,7 @@ class RenderingLibrary:
       pass
     def draw_sphere()
       pass
+```
 
 Our library will have 3 simple functions, one for clearing the screen, one for drawing a cube and one for drawing an sphere. It by default has some lighting to make the output image feel more 3D. We don’t care how the interface is implemented, but we’ll use it in our code. A working implementation will be provided in the git repo of the book!
 


### PR DESCRIPTION
Hey Keyvan,

There was some text misplaced inside a code block (pages 238–239), which messed up the Markdown rendering and caused the PDF to be incomplete.

Fixed it in this PR.

<div float="left">
  <img src="https://github.com/user-attachments/assets/3bea8a14-2560-435c-99f6-519fd29dfd3c" alt="Before" width="45%" style="margin-right: 10px;">
  <img src="https://github.com/user-attachments/assets/473b5be5-6511-4eaf-8c26-bd0598f46fa3" alt="After" width="45%">
</div>



